### PR TITLE
Inflexible tag semver algorithm for monorepo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build
 cmake-build-debug-with-additional-options
 cmake-build-debug
+cmake-build-release
 .DS_Store
 .idea

--- a/include/providers/provider.h
+++ b/include/providers/provider.h
@@ -86,7 +86,7 @@ namespace providers {
         /**
          * Returns the latest released tag for the underlining repository.
          */
-        GitTag lastReleasedTag();
+        GitTag lastReleasedTag(const std::string& tagsFilter);
 
         /**
          * Determines if the current head is a tag or not.

--- a/include/semver.h
+++ b/include/semver.h
@@ -23,7 +23,7 @@ namespace gitsemver {
          * Branch name will be omitted for develop and master.
          * In case the tool is executed against a tag, the tag name will be returned.
          */
-        std::string nextVersion() const;
+        std::string nextVersion(const std::string& tagsFilter) const;
 
         virtual ~Semver() noexcept = default;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 
 DEFINE_int32(shalength, 6, "Controls how many characters to keep from the latest commit sha.");
 DEFINE_string(repository, "./", "Controls the repository for which we try to determine the next release version.");
+DEFINE_string(filter, "", "Optionally apply a regex filter in order to accommodate mono repos. In case this is not specified all tags are considered.");
 
 int main(int argc, char** argv) {
     #ifdef DEBUG
@@ -16,10 +17,15 @@ int main(int argc, char** argv) {
 
     auto shaLength = FLAGS_shalength;
     auto repository = FLAGS_repository.c_str();
+    std::string tagsFilter = FLAGS_filter;
+
+    if (!tagsFilter.empty()) {
+        spdlog::debug("Using {} filtering for the semantic versioning.", tagsFilter);
+    }
 
     auto provider = gitsemver::providers::newDefaultProvider(repository);
     auto semver = gitsemver::Semver(provider.get(), shaLength);
-    auto suggestedVersion = semver.nextVersion();
+    auto suggestedVersion = semver.nextVersion(tagsFilter);
     std::cout << suggestedVersion;
     return 0;
 }

--- a/src/semver.cpp
+++ b/src/semver.cpp
@@ -1,5 +1,4 @@
 #include <string>
-#include <spdlog/spdlog.h>
 
 #include <providers/provider.h>
 #include <semver.h>
@@ -7,8 +6,8 @@
 namespace gitsemver {
     static const std::string DEFAULT_VERSION = "1.0.0";
 
-    std::string Semver::nextVersion() const {
-        auto tag = gitProvider_->lastReleasedTag();
+    std::string Semver::nextVersion(const std::string& tagsFilter) const {
+        auto tag = gitProvider_->lastReleasedTag(tagsFilter);
         if (tag == providers::NO_GIT_TAG) {
             return toSemanticVersionWithPrefix(DEFAULT_VERSION);
         }


### PR DESCRIPTION
We now have the possibility to specify a filter for the tags we want to include in determining the semantic versioning calculation.

Closes #21